### PR TITLE
Example update

### DIFF
--- a/examples/keypad_generic/keypad_generic.ino
+++ b/examples/keypad_generic/keypad_generic.ino
@@ -1,0 +1,36 @@
+#include "Adafruit_Keypad.h"
+
+const byte ROWS = 4; // rows
+const byte COLS = 4; // columns
+//define the symbols on the buttons of the keypads
+char keys[ROWS][COLS] = {
+  {'1','2','3','A'},
+  {'4','5','6','B'},
+  {'7','8','9','C'},
+  {'*','0','#','D'}
+};
+byte rowPins[ROWS] = {5, 4, 3, 2}; //connect to the row pinouts of the keypad
+byte colPins[COLS] = {11, 10, 9, 8}; //connect to the column pinouts of the keypad
+
+//initialize an instance of class NewKeypad
+Adafruit_Keypad customKeypad = Adafruit_Keypad( makeKeymap(keys), rowPins, colPins, ROWS, COLS);
+
+void setup() {
+  Serial.begin(9600);
+  customKeypad.begin();
+
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+  customKeypad.tick();
+
+  while(customKeypad.available()){
+    keypadEvent e = customKeypad.read();
+    Serial.print((char)e.bit.KEY);
+    if(e.bit.EVENT == KEY_JUST_PRESSED) Serial.println(" pressed");
+    else if(e.bit.EVENT == KEY_JUST_RELEASED) Serial.println(" released");
+  }
+
+  delay(10);
+}

--- a/examples/keypad_test/keypad_config.h
+++ b/examples/keypad_test/keypad_config.h
@@ -1,0 +1,44 @@
+// This file contains predefined setup for various Adafruit Matrix Keypads.
+#ifndef __KEYPAD_CONFIG_H__
+#define __KEYPAD_CONFIG_H__
+
+#if defined(KEYPAD_PID3844)
+const byte ROWS = 4; // rows
+const byte COLS = 4; // columns
+//define the symbols on the buttons of the keypads
+char keys[ROWS][COLS] = {
+  {'1','2','3','A'},
+  {'4','5','6','B'},
+  {'7','8','9','C'},
+  {'*','0','#','D'}
+};
+byte rowPins[ROWS] = {R1, R2, R3, R4}; //connect to the row pinouts of the keypad
+byte colPins[COLS] = {C1, C2, C3, C4}; //connect to the column pinouts of the keypad
+#endif
+
+#if defined(KEYPAD_PID1824) || defined(KEYPAD_PID3845) || defined(KEYPAD_PID419)
+const byte ROWS = 4; // rows
+const byte COLS = 3; // columns
+//define the symbols on the buttons of the keypads
+char keys[ROWS][COLS] = {
+  {'1','2','3'},
+  {'4','5','6'},
+  {'7','8','9'},
+  {'*','0','#'}
+};
+byte rowPins[ROWS] = {R1, R2, R3, R4}; //connect to the row pinouts of the keypad
+byte colPins[COLS] = {C1, C2, C3}; //connect to the column pinouts of the keypad
+#endif
+
+#if defined(KEYPAD_PID1332)
+const byte ROWS = 1; // rows
+const byte COLS = 4; // columns
+//define the symbols on the buttons of the keypads
+char keys[ROWS][COLS] = {
+  {'1','2','3','4'},
+};
+byte rowPins[ROWS] = {R1}; //connect to the row pinouts of the keypad
+byte colPins[COLS] = {C1, C2, C3, C4}; //connect to the column pinouts of the keypad
+#endif
+
+#endif

--- a/examples/keypad_test/keypad_config.h
+++ b/examples/keypad_test/keypad_config.h
@@ -5,40 +5,39 @@
 #if defined(KEYPAD_PID3844)
 const byte ROWS = 4; // rows
 const byte COLS = 4; // columns
-//define the symbols on the buttons of the keypads
-char keys[ROWS][COLS] = {
-  {'1','2','3','A'},
-  {'4','5','6','B'},
-  {'7','8','9','C'},
-  {'*','0','#','D'}
-};
-byte rowPins[ROWS] = {R1, R2, R3, R4}; //connect to the row pinouts of the keypad
-byte colPins[COLS] = {C1, C2, C3, C4}; //connect to the column pinouts of the keypad
+// define the symbols on the buttons of the keypads
+char keys[ROWS][COLS] = {{'1', '2', '3', 'A'},
+                         {'4', '5', '6', 'B'},
+                         {'7', '8', '9', 'C'},
+                         {'*', '0', '#', 'D'}};
+byte rowPins[ROWS] = {R1, R2, R3,
+                      R4}; // connect to the row pinouts of the keypad
+byte colPins[COLS] = {C1, C2, C3,
+                      C4}; // connect to the column pinouts of the keypad
 #endif
 
 #if defined(KEYPAD_PID1824) || defined(KEYPAD_PID3845) || defined(KEYPAD_PID419)
 const byte ROWS = 4; // rows
 const byte COLS = 3; // columns
-//define the symbols on the buttons of the keypads
+// define the symbols on the buttons of the keypads
 char keys[ROWS][COLS] = {
-  {'1','2','3'},
-  {'4','5','6'},
-  {'7','8','9'},
-  {'*','0','#'}
-};
-byte rowPins[ROWS] = {R1, R2, R3, R4}; //connect to the row pinouts of the keypad
-byte colPins[COLS] = {C1, C2, C3}; //connect to the column pinouts of the keypad
+    {'1', '2', '3'}, {'4', '5', '6'}, {'7', '8', '9'}, {'*', '0', '#'}};
+byte rowPins[ROWS] = {R1, R2, R3,
+                      R4};         // connect to the row pinouts of the keypad
+byte colPins[COLS] = {C1, C2, C3}; // connect to the column pinouts of the
+                                   // keypad
 #endif
 
 #if defined(KEYPAD_PID1332)
 const byte ROWS = 1; // rows
 const byte COLS = 4; // columns
-//define the symbols on the buttons of the keypads
+// define the symbols on the buttons of the keypads
 char keys[ROWS][COLS] = {
-  {'1','2','3','4'},
+    {'1', '2', '3', '4'},
 };
-byte rowPins[ROWS] = {R1}; //connect to the row pinouts of the keypad
-byte colPins[COLS] = {C1, C2, C3, C4}; //connect to the column pinouts of the keypad
+byte rowPins[ROWS] = {R1}; // connect to the row pinouts of the keypad
+byte colPins[COLS] = {C1, C2, C3,
+                      C4}; // connect to the column pinouts of the keypad
 #endif
 
 #endif

--- a/examples/keypad_test/keypad_test.ino
+++ b/examples/keypad_test/keypad_test.ino
@@ -1,16 +1,28 @@
+// Use this example with the Adafruit Keypad products.
+// You'll need to know the Product ID for your keypad.
+// Here's a summary:
+//   * PID3844 4x4 Matrix Keypad
+//   * PID3845 3x4 Matrix Keypad
+//   * PID1824 3x4 Phone-style Matrix Keypad
+//   * PID1332 Membrane 1x4 Keypad
+//   * PID419  Membrane 3x4 Matrix Keypad
+
 #include "Adafruit_Keypad.h"
 
-const byte ROWS = 4; // rows
-const byte COLS = 4; // columns
-//define the symbols on the buttons of the keypads
-char keys[ROWS][COLS] = {
-  {'1','2','3','A'},
-  {'4','5','6','B'},
-  {'7','8','9','C'},
-  {'*','0','#','D'}
-};
-byte rowPins[ROWS] = {5, 4, 3, 2}; //connect to the row pinouts of the keypad
-byte colPins[COLS] = {11, 10, 9, 8}; //connect to the column pinouts of the keypad
+// define your specific keypad here via
+#define KEYPAD_PID3844
+// define your pins here
+// can ignore ones that don't apply
+#define R1    2
+#define R2    3
+#define R3    4
+#define R4    5
+#define C1    8
+#define C2    9
+#define C3    10
+#define C4    11
+// leave this import after the above configuration
+#include "keypad_config.h"
 
 //initialize an instance of class NewKeypad
 Adafruit_Keypad customKeypad = Adafruit_Keypad( makeKeymap(keys), rowPins, colPins, ROWS, COLS);
@@ -18,7 +30,6 @@ Adafruit_Keypad customKeypad = Adafruit_Keypad( makeKeymap(keys), rowPins, colPi
 void setup() {
   Serial.begin(9600);
   customKeypad.begin();
-
 }
 
 void loop() {

--- a/examples/keypad_test/keypad_test.ino
+++ b/examples/keypad_test/keypad_test.ino
@@ -9,7 +9,7 @@
 
 #include "Adafruit_Keypad.h"
 
-// define your specific keypad here via
+// define your specific keypad here via PID
 #define KEYPAD_PID3844
 // define your pins here
 // can ignore ones that don't apply


### PR DESCRIPTION
Example updates to go along with forthcoming guide update.

* Previous generic example `keypad_test` moved to `keypad_generic`
* The `keypad_test` example updated to include settings for all current Adafruit Keypads
    * PID3844 4x4 Matrix Keypad
    * PID3845 3x4 Matrix Keypad
    * PID1824 3x4 Phone-style Matrix Keypad
    * PID1332 Membrane 1x4 Keypad
    * PID419  Membrane 3x4 Matrix Keypad